### PR TITLE
Add support for ice restarts

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -100,6 +100,7 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
   onremovestream: ?Function;
 
   _peerConnectionId: number;
+  _localStreams: Array<MediaStream> = [];
   _remoteStreams: Array<MediaStream> = [];
   _subscriptions: Array<any>;
 
@@ -127,10 +128,15 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
 
   addStream(stream: MediaStream) {
     WebRTCModule.peerConnectionAddStream(stream.reactTag, this._peerConnectionId);
+    this._localStreams.push(stream);
   }
 
   removeStream(stream: MediaStream) {
     WebRTCModule.peerConnectionRemoveStream(stream.reactTag, this._peerConnectionId);
+    let index = this._localStreams.indexOf(stream);
+    if (index !== -1) {
+      this._localStreams.splice(index, 1);
+    }
   }
 
   createOffer(options) {
@@ -203,6 +209,10 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
     } else {
       console.warn('RTCPeerConnection getStats not supported');
     }
+  }
+
+  getLocalStreams() {
+    return this._localStreams.slice();
   }
 
   getRemoteStreams() {

--- a/RTCUtil.js
+++ b/RTCUtil.js
@@ -20,6 +20,9 @@ export function mergeMediaConstraints(custom, def) {
     if (custom.facingMode) {
       constraints.facingMode = custom.facingMode.toString(); // string, 'user' or the default 'environment'
     }
+    if (custom.iceRestart) {
+      constraints.mandatory = {...constraints.mandatory, IceRestart: true };
+    }
   }
   return constraints;
 }


### PR DESCRIPTION
Simple change to allow `IceRestart` to occur, works on both Android and iOS.
Also cherry picked support fro `getLocalStreams` from upstream.