### PR TITLE
fix video not rendering on iOS 13

### DIFF
--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -120,16 +120,26 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  */
 - (instancetype)initWithFrame:(CGRect)frame {
   if (self = [super initWithFrame:frame]) {
-#if defined(RTC_SUPPORTS_METAL)
-    RTCMTLVideoView *subview = [[RTCMTLVideoView alloc] initWithFrame:CGRectZero];
-    subview.delegate = self;
-    _videoView = subview;
-#else
-    RTCEAGLVideoView *subview = [[RTCEAGLVideoView alloc] initWithFrame:CGRectZero];
-    subview.delegate = self;
-    _videoView = subview;
-#endif
+  
+    if (@available(iOS 13, *)) {
+      // Currently, the metal backed view doesn't render remote video on iOS 13.
+      // TODO: Check if this is resolved in later iOS13 betas / a WebRTC update
+      RTCEAGLVideoView *subview = [[RTCEAGLVideoView alloc] initWithFrame:CGRectZero];
+      subview.delegate = self;
+      _videoView = subview;
 
+    } else {
+      #if defined(RTC_SUPPORTS_METAL)
+        RTCMTLVideoView *subview = [[RTCMTLVideoView alloc] initWithFrame:CGRectZero];
+        subview.delegate = self;
+        _videoView = subview;
+      #else
+        RTCEAGLVideoView *subview = [[RTCEAGLVideoView alloc] initWithFrame:CGRectZero];
+        subview.delegate = self;
+        _videoView = subview;
+      #endif
+    }
+  
     _videoSize.height = 0;
     _videoSize.width = 0;
 


### PR DESCRIPTION
use OpenGL on iOS 13 to get the video. 